### PR TITLE
Game

### DIFF
--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -1,5 +1,5 @@
 class BALL_CONSTS:
-    RADIUS = 7
+    RADIUS = 9
     INITIAL_X = 400
     INITIAL_Y = 0
     INITIAL_DX = 3
@@ -10,11 +10,11 @@ class BALL_CONSTS:
 
 class PADDLE_CONSTS:
     INITIAL_Y = 300
-    HEIGHT = 60
+    HEIGHT = 80
     WIDTH = 10
     SPEED = 11
-    PADDLE1_X = 10
-    PADDLE2_X = 790
+    PADDLE1_X = 12
+    PADDLE2_X = 788
 
 
 class CANVAS_CONSTS:

--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -32,14 +32,3 @@ class GAME_CONSTS:
     INTERVAL_TIME = 1.5
     LEFT_SIDE = 0
     RIGHT_SIDE = 1
-
-
-''' need to change the controls in js script
-to modify the controls '''
-
-
-class CONTROLS_CONSTS:
-    P1_UP_KEY = 'w'
-    P1_DOWN_KEY = 's'
-    P2_UP_KEY = 'ArrowUp'
-    P2_DOWN_KEY = 'ArrowDown'

--- a/drf-api-game/src/game/consumers.py
+++ b/drf-api-game/src/game/consumers.py
@@ -41,7 +41,7 @@ class GameConnection(AsyncWebsocketConsumer):
     async def receive(self, text_data):
         text_data_json = json.loads(text_data)
         command = text_data_json['command']
-        keys_pressed = text_data_json.get('keysPressed', {})
+        actions = text_data_json.get('actions', {})
 
-        if command == "keys":
-            self.game.update_key_states(keys_pressed)
+        if command == "actions":
+            self.game.update_actions(actions)

--- a/drf-api-game/src/game/game.py
+++ b/drf-api-game/src/game/game.py
@@ -38,11 +38,11 @@ class Game:
             BALL.HIT_DX,
             BALL.COLLISION_COEFF
         )
-        self.keys_pressed = {
-            self.player1.controls['up']: False,
-            self.player1.controls['down']: False,
-            self.player2.controls['up']: False,
-            self.player2.controls['down']: False,
+        self.actions = {
+            'p1Up': False,
+            'p1Down': False,
+            'p2Up': False,
+            'p2Down': False
         }
         self.resetting = True
         self.reset_time = GAME.INTERVAL_TIME
@@ -57,18 +57,18 @@ class Game:
             self.table
         )
 
-    def update_key_states(self, keys_pressed: dict) -> None:
-        self.keys_pressed = keys_pressed
+    def update_actions(self, actions: dict) -> None:
+        self.actions = actions
 
     def update(self) -> None:
         self.ball.update_position()
         self.player1.paddle.update_position(
-            self.keys_pressed,
-            self.player1.controls
+            self.actions['p1Up'],
+            self.actions['p1Down']
         )
         self.player2.paddle.update_position(
-            self.keys_pressed,
-            self.player2.controls
+            self.actions['p2Up'],
+            self.actions['p2Down']
         )
         self.check_collisions()
         if self.resetting is False and self.player_scored():

--- a/drf-api-game/src/game/models/ball.py
+++ b/drf-api-game/src/game/models/ball.py
@@ -1,6 +1,6 @@
 class Ball:
-    def __init__(self, x: int, y: int, radius: int, dx: int, dy: int, 
-                 hit_dx: int, hit_coeff: float):
+    def __init__(self, x: float, y: float, radius: float, dx: float, dy: float, 
+                 hit_dx: float, hit_coeff: float):
         self.x = x
         self.y = y
         self.radius = radius

--- a/drf-api-game/src/game/models/paddle.py
+++ b/drf-api-game/src/game/models/paddle.py
@@ -12,15 +12,15 @@ class Paddle:
         self.hitbox = self.get_hitbox()
         self.dy = 0
 
-    def update_position(self, keys_pressed: dict, controls: dict) -> None:
-        self.update_velocity(keys_pressed, controls)
+    def update_position(self, up: bool, down: bool) -> None:
+        self.update_velocity(up, down)
         self.move()
 
-    def update_velocity(self, keys_pressed: dict, controls: dict) -> None:
+    def update_velocity(self, up: bool, down: bool) -> None:
         self.velocity = 0
-        if keys_pressed[controls['up']]:
+        if up:
             self.velocity -= self.speed
-        if keys_pressed[controls['down']]:
+        if  down:
             self.velocity += self.speed
 
     def move(self) -> None:

--- a/drf-api-game/src/game/models/player.py
+++ b/drf-api-game/src/game/models/player.py
@@ -1,7 +1,6 @@
 from game.constants import (
     GAME_CONSTS as GAME, 
-    PADDLE_CONSTS as PADDLE, 
-    CONTROLS_CONSTS as CTRL
+    PADDLE_CONSTS as PADDLE,
 )
 from game.models.paddle import Paddle
 
@@ -17,7 +16,6 @@ class Player:
             PADDLE.SPEED
         )
         self.score = 0
-        self.controls = self.get_controls()
         self.goal = goal
         self.playing_side = (self.paddle.x > self.goal)
     
@@ -29,9 +27,3 @@ class Player:
 
     def update_score(self) -> None:
         self.score += 1
-
-    def get_controls(self) -> dict:
-        if self.id == GAME.PLAYER1:
-            return {'up': CTRL.P1_UP_KEY, 'down': CTRL.P1_DOWN_KEY}
-        else:
-            return {'up': CTRL.P2_UP_KEY, 'down': CTRL.P2_DOWN_KEY}

--- a/webserver/app/index.html
+++ b/webserver/app/index.html
@@ -4,6 +4,9 @@
 	<meta charset="UTF-8">
 	<title>transcendence</title>
 
+	<!-- Google Font -->
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+
 	<!-- Bootstrap -->
 	<link rel="stylesheet" href="static/bootstrap/bootstrap.min.css">
 	<script src="static/bootstrap/bootstrap.min.js"></script>

--- a/webserver/app/static/js/pong/game_handler.js
+++ b/webserver/app/static/js/pong/game_handler.js
@@ -1,23 +1,32 @@
 export const gameState = {
-    keysPressed: {
-        ArrowUp: false,
-        ArrowDown: false,
-        w: false,
-        s: false
+    actions: {
+        p1Up: false,
+        p1Down: false,
+        p2Up: false,
+        p2Down: false
     },
     gameStarted: false
 };
 
+const keyToActionMap = {
+    'w': 'p1Up',
+    's': 'p1Down',
+    'ArrowUp': 'p2Up',
+    'ArrowDown': 'p2Down'
+};
+
 export function handlerGameLoop() {
     document.addEventListener('keydown', function(event) {
-        if (event.key in gameState.keysPressed) {
-            gameState.keysPressed[event.key] = true;
+        const action = keyToActionMap[event.key];
+        if (action) {
+            gameState.actions[action] = true;
         }
     });
 
     document.addEventListener('keyup', function(event) {
-        if (event.key in gameState.keysPressed) {
-            gameState.keysPressed[event.key] = false;
+        const action = keyToActionMap[event.key];
+        if (action) {
+            gameState.actions[action] = false;
         }
     });
 }

--- a/webserver/app/static/js/pong/network.js
+++ b/webserver/app/static/js/pong/network.js
@@ -4,11 +4,11 @@ import { drawGame } from './game_display.js';
 
 let socket;
 
-function sendKeyStates() {
+function sendActions() {
     if (socket.readyState === WebSocket.OPEN) {
         socket.send(JSON.stringify({
-            command: "keys",
-            keysPressed: gameState.keysPressed
+            command: "actions",
+            actions: gameState.actions
         }));
     }
 }
@@ -22,7 +22,7 @@ export function handlerNetwork(canvas, context) {
 
         socket.onopen = function(e) {
             console.debug('WebSocket connection established');
-            setInterval(sendKeyStates, INTERVAL_DURATION);
+            setInterval(sendActions, INTERVAL_DURATION);
         };
 
         socket.onmessage = function(e) {


### PR DESCRIPTION
Petite pull request, très simple.

Au lieu d'envoyer les clés appuyées par les joueurs au serveur, le front envoie des 'actions' à la place.

exemple: "p1Up" "p2Down", au lieu de 'w' 'arrowDown'

Supprimé les consts regardant les controls sur le server side, puisquils étaient rendu non-nécessaires.

Rajouter le font pour le jeu dans index.html

Notion : https://www.notion.so/tonted/Game-Flow-Frontend-Based-7226e555a1fb497cb3b80efffaef863e?pvs=4

Ah oui et jai aussi grossi un peu les paddles et la balle pour rendre le jeu plus facile un peu