### PR TITLE
update host and game status

### DIFF
--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -26,7 +26,7 @@ class CANVAS_CONSTS:
 
 class GAME_CONSTS:
     FPS = 64
-    WINNING_SCORE = 1
+    WINNING_SCORE = 4
     PLAYER1 = 1
     PLAYER2 = 2
     INTERVAL_TIME = 1.5


### PR DESCRIPTION
game_display.js:    remettre GAMEDATA à null pour fixer le bug du jeu qui ne s'affichait pour les parties consécutives. voir la 
                              function updateData dans le meme fichier. puisque GAMEDATA n'était pas reset à null, la function drawgame 
                              n'était pas appelé à nouveau.

network.js:             remettre la valeur de gamestate.gameStarted à false à la déconnexion du socket pour pouvoir démarrer les 
                              parties consécutives. voir la function handlerStartMenu dans menu_handler.js, la function startGame() ne 
                              pouvait etre quappeler si gameState.gameStarted était false. Alors qu'avant de  fix, le gameStarted nétait 
                              jamais modifié à la fin d'une partie

consumers.py:     - rajout de la méthode get_params pour avoir les paramètres et obtenir soit le game_id ou le jwt token (je 
                              trouvais ca plus propre de faire ca que de réécrire les memes lignes pour le jwt et le game_id).
                            - rajout de la méthode update_host_status pour updater le status du host.
                            - modification de la methode update_game, qui prend en argument l'état de la partie.
                            - modification de la methode game_loop, qui maintenant update le score de la partie dans la database a chaque
                            but au lieu que seulement à la fin. Reste à voir si ca vaut le coup de faire ca