### PR TITLE
Game update status

### DIFF
--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -26,7 +26,7 @@ class CANVAS_CONSTS:
 
 class GAME_CONSTS:
     FPS = 64
-    WINNING_SCORE = 4
+    WINNING_SCORE = 1
     PLAYER1 = 1
     PLAYER2 = 2
     INTERVAL_TIME = 1.5

--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -26,7 +26,7 @@ class CANVAS_CONSTS:
 
 class GAME_CONSTS:
     FPS = 64
-    WINNING_SCORE = 1
+    WINNING_SCORE = 4
     PLAYER1 = 1
     PLAYER2 = 2
     INTERVAL_TIME = 1.5

--- a/drf-api-game/src/game/constants.py
+++ b/drf-api-game/src/game/constants.py
@@ -26,7 +26,7 @@ class CANVAS_CONSTS:
 
 class GAME_CONSTS:
     FPS = 64
-    WINNING_SCORE = 1
+    WINNING_SCORE = 3
     PLAYER1 = 1
     PLAYER2 = 2
     INTERVAL_TIME = 1.5

--- a/drf-api-game/src/gameManager/views.py
+++ b/drf-api-game/src/gameManager/views.py
@@ -89,7 +89,10 @@ def update_game(game_id, game_data):
     try:
         game = Game.objects.get(id=game_id)
         game.status = game_data.get('status')
-        game.winner_id = game_data.get('winner_id')
+        if game_data.get('winner_id') == 1:
+            game.winner_id = game.player1_id
+        else:
+            game.winner_id = game.player2_id
         game.player1_score = game_data.get('player1_score')
         game.player2_score = game_data.get('player2_score')
         game.save()

--- a/webserver/app/static/js/index/game_manager.js
+++ b/webserver/app/static/js/index/game_manager.js
@@ -67,7 +67,7 @@ function displayGames(games) {
 async function launchGame(game) {
   const gameContainer = document.getElementById("gameContainer");
   gameContainer.innerHTML = `<canvas id="pongCanvas" width="800" height="600" style="background: #000; display: block; margin: 0 auto"></canvas>`;
-  loadCanvasGame(game.id);
+  loadCanvasGame(game.id, game.player1_name, game.player2_name);
   // TODO-GVAR: handle end of game and remove canvas
 }
 

--- a/webserver/app/static/js/pong/constants.js
+++ b/webserver/app/static/js/pong/constants.js
@@ -14,20 +14,20 @@ export const CANVAS = Object.freeze({
 
 export const SCORE = Object.freeze({
     PLAYER1_Y: 50,
-    PLAYER1_X: 200,
+    PLAYER1_X: 350,
     PLAYER2_Y: 50,
-    PLAYER2_X: 600,
+    PLAYER2_X: 450,
     FONT: 'Press Start 2P',
-    FONT_SIZE: '30px',
+    FONT_SIZE: '25px',
     COLOR: 'white',
     TEXT_ALIGN: 'center',
 });
 
 export const PLAY_BUTTON = Object.freeze({
     X: 400,
-    Y: 300,
+    Y: 400,
     FONT: 'Press Start 2P',
-    FONT_SIZE: '30px',
+    FONT_SIZE: '25px',
     COLOR: 'white',
     HIGHLIGHT: 'blue',
     TEXT_ALIGN: 'center',
@@ -42,6 +42,17 @@ export const FINAL_SCORE = Object.freeze({
     FONT_SIZE: '30px',
     COLOR: 'white',
     TEXT_ALIGN: 'center',
+});
+
+export const PLAYERS = Object.freeze({
+    PLAYER1_X: 200,
+    PLAYER1_Y: 250,
+    PLAYER2_X: 600,
+    PLAYER2_Y: 250,
+    FONT: 'Press Start 2P',
+    FONT_SIZE: '25px',
+    COLOR: 'white',
+    TEXT_ALIGN: 'center', 
 });
 
 export const INTERVAL_DURATION = 1000 / 60;

--- a/webserver/app/static/js/pong/game_display.js
+++ b/webserver/app/static/js/pong/game_display.js
@@ -1,6 +1,6 @@
 import { NET, CANVAS, SCORE, FINAL_SCORE, BALL_COLOR, PADDLES_COLOR } from "./constants.js";
 import { clearCanvas } from './menu_display.js'
-import { gameIsInPlay, winnerIsDecided } from './game_handler.js';
+import { gameIsInPlay, gameState, winnerIsDecided } from './game_handler.js';
 
 let GAMEDATA = null;
 let RUNNINGID = null;
@@ -33,16 +33,20 @@ function drawScores(context, canvas, scores) {
     context.fillStyle = SCORE.COLOR;
     context.font = `${SCORE.FONT_SIZE} "${SCORE.FONT}"`;
     context.textAlign = SCORE.TEXT_ALIGN;
+    
+    context.fillText(gameState.players.p1Name, 200, SCORE.PLAYER1_Y);
+    context.fillText(gameState.players.p2Name, 600, SCORE.PLAYER2_Y);
     context.fillText(scores.player1, SCORE.PLAYER1_X, SCORE.PLAYER1_Y);
     context.fillText(scores.player2, SCORE.PLAYER2_X, SCORE.PLAYER2_Y);
 }
 
 export function drawWinner(context, canvas, winner, scores) {
+    const text = winner == 1 ? gameState.players.p1Name : gameState.players.p2Name
     clearCanvas(context, canvas);
     context.fillStyle = FINAL_SCORE.COLOR;
     context.font = `${SCORE.FONT_SIZE} "${SCORE.FONT}"`;
     context.textAlign = FINAL_SCORE.TEXT_ALIGN;
-    context.fillText(`PLAYER ${winner} WINS`, FINAL_SCORE.WINNER_X, FINAL_SCORE.WINNER_Y);
+    context.fillText(`${text} WINS`, FINAL_SCORE.WINNER_X, FINAL_SCORE.WINNER_Y);
     context.fillText(`${scores.player1} - ${scores.player2}`, FINAL_SCORE.SCORE_X, FINAL_SCORE.SCORE_Y);
     cancelAnimationFrame(RUNNINGID);
     GAMEDATA = null;

--- a/webserver/app/static/js/pong/game_display.js
+++ b/webserver/app/static/js/pong/game_display.js
@@ -45,6 +45,7 @@ export function drawWinner(context, canvas, winner, scores) {
     context.fillText(`PLAYER ${winner} WINS`, FINAL_SCORE.WINNER_X, FINAL_SCORE.WINNER_Y);
     context.fillText(`${scores.player1} - ${scores.player2}`, FINAL_SCORE.SCORE_X, FINAL_SCORE.SCORE_Y);
     cancelAnimationFrame(RUNNINGID);
+    GAMEDATA = null;
 }
 
 

--- a/webserver/app/static/js/pong/game_handler.js
+++ b/webserver/app/static/js/pong/game_handler.js
@@ -5,7 +5,11 @@ export const gameState = {
         p2Up: false,
         p2Down: false
     },
-    gameStarted: false
+    gameStarted: false,
+    players: {
+        p1Name: null,
+        p2Name: null
+    }
 };
 
 const keyToActionMap = {

--- a/webserver/app/static/js/pong/main.js
+++ b/webserver/app/static/js/pong/main.js
@@ -2,11 +2,11 @@ import { handlerStartMenu } from "./menu_handler.js";
 import { handlerGameLoop } from "./game_handler.js";
 import { handlerNetwork } from "./network.js";
 
-export const loadCanvasGame = (game_id) => {
+export const loadCanvasGame = (game_id, player1_name, player2_name) => {
   const canvas = document.getElementById("pongCanvas");
   const context = canvas.getContext("2d");
 
-  handlerStartMenu(canvas, context);
+  handlerStartMenu(canvas, context, player1_name, player2_name);
   handlerGameLoop();
   handlerNetwork(canvas, context, game_id);
 };

--- a/webserver/app/static/js/pong/menu_display.js
+++ b/webserver/app/static/js/pong/menu_display.js
@@ -1,17 +1,40 @@
-import { CANVAS, PLAY_BUTTON } from './constants.js';
+import { CANVAS, PLAY_BUTTON, PLAYERS } from './constants.js';
+import { gameState } from './game_handler.js';
 import { isMouseOverPlayButton } from './menu_handler.js';
 
 export function clearCanvas(context, canvas) {
     context.clearRect(CANVAS.ORIGIN_X, CANVAS.ORIGIN_Y, canvas.width, canvas.height);
 }
 
-export function drawPlayButton(canvas, context) {
-    clearCanvas(context, canvas);
+function drawPlayButton(canvas, context) {
     context.fillStyle = isMouseOverPlayButton(canvas, context) ? PLAY_BUTTON.HIGHLIGHT : PLAY_BUTTON.COLOR;
     context.font = `${PLAY_BUTTON.FONT_SIZE} "${PLAY_BUTTON.FONT}"`;
     context.textAlign = PLAY_BUTTON.TEXT_ALIGN;
-    const textMetrics = context.measureText('PLAY');
+    const textMetrics = context.measureText('START');
     const textHeight = textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent;
     const textWidth = textMetrics.width;
-    context.fillText('PLAY', PLAY_BUTTON.X , PLAY_BUTTON.Y + textHeight / 2);
+    context.fillText('START', PLAY_BUTTON.X , PLAY_BUTTON.Y + textHeight / 2);
+}
+
+function drawPlayersNames(canvas, context) {
+    const player1 = gameState.players.p1Name;
+    const player2 = gameState.players.p2Name;
+    
+    context.fillStyle = PLAYERS.COLOR;
+    context.font = `${PLAYERS.FONT_SIZE} "${PLAYERS.FONT}"`;
+    context.textAlign = PLAYERS.TEXT_ALIGN;
+    
+    context.fillText(player1, PLAYERS.PLAYER1_X , PLAYERS.PLAYER1_Y);
+    context.fillText('vs.', CANVAS.CENTER_X , PLAYERS.PLAYER1_Y);
+    context.fillText(player2, PLAYERS.PLAYER2_X , PLAYERS.PLAYER2_Y);
+}
+
+function drawControls(canvas, context) {
+}
+
+export function drawMenu(canvas, context) {
+    clearCanvas(context, canvas);
+    drawPlayButton(canvas, context);
+    drawPlayersNames(canvas, context);
+    drawControls(canvas, context);
 }

--- a/webserver/app/static/js/pong/menu_handler.js
+++ b/webserver/app/static/js/pong/menu_handler.js
@@ -1,16 +1,18 @@
 import { PLAY_BUTTON } from './constants.js';
 import { gameState } from './game_handler.js';
-import { drawPlayButton } from './menu_display.js';
+import { drawMenu } from './menu_display.js';
 
 let mouseX, mouseY;
 
-export function handlerStartMenu(canvas, context) {
+export function handlerStartMenu(canvas, context, player1_name, player2_name) {
+    gameState.players.p1Name = player1_name;
+    gameState.players.p2Name = player2_name;
     document.addEventListener('mousemove', function(event) {
         const rect = canvas.getBoundingClientRect();
         mouseX = event.clientX - rect.left;
         mouseY = event.clientY - rect.top;
         if (!gameState.gameStarted) {
-            drawPlayButton(canvas, context);
+            drawMenu(canvas, context);
         }
     });
 
@@ -22,11 +24,11 @@ export function handlerStartMenu(canvas, context) {
         }
     });
 
-    document.fonts.ready.then(() => drawPlayButton(canvas, context));
+    document.fonts.ready.then(() => drawMenu(canvas, context));
 }
 
 export function isMouseOverPlayButton(canvas, context) {
-    const textMetrics = context.measureText('PLAY');
+    const textMetrics = context.measureText('START');
     const textHeight = textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent;
     const textWidth = textMetrics.width;
     const buttonLeft = PLAY_BUTTON.X - textWidth / 2;

--- a/webserver/app/static/js/pong/network.js
+++ b/webserver/app/static/js/pong/network.js
@@ -23,6 +23,7 @@ async function displayGameEnded(context, canvas, data) {
 
   await new Promise((r) => setTimeout(r, FINAL_SCORES_DURATION));
   canvas.remove();
+  gameState.gameStarted = false;
   await contentLoader.load("form_game");
   initGameForm();
   // TODO-GVAR: handle end of game and remove canvas
@@ -50,7 +51,7 @@ export function handlerNetwork(canvas, context, game_id) {
         displayGameEnded(context, canvas, data.final);
       }
     };
-
+    
     socket.onclose = async function (e) {
       console.debug("WebSocket connection closed");
     };


### PR DESCRIPTION
game_display.js: remettre GAMEDATA à null pour fixer le bug du jeu qui ne s'affichait pour les parties consécutives. voir la
function updateData dans le meme fichier. puisque GAMEDATA n'était pas reset à null, la function drawgame
n'était pas appelé à nouveau.

network.js: remettre la valeur de gamestate.gameStarted à false à la déconnexion du socket pour pouvoir démarrer les
parties consécutives. voir la function handlerStartMenu dans menu_handler.js, la function startGame() ne
pouvait etre quappeler si gameState.gameStarted était false. Alors qu'avant de fix, le gameStarted nétait
jamais modifié à la fin d'une partie

consumers.py: - rajout de la méthode get_params pour avoir les paramètres et obtenir soit le game_id ou le jwt token (je
trouvais ca plus propre de faire ca que de réécrire les memes lignes pour le jwt et le game_id).
- rajout de la méthode update_host_status pour updater le status du host.
- modification de la methode update_game, qui prend en argument l'état de la partie.
- modification de la methode game_loop, qui maintenant update le score de la partie dans la database a chaque
but au lieu que seulement à la fin. Reste à voir si ca vaut le coup de faire ca